### PR TITLE
Add output formatters package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,10 @@ config/secrets.yaml
 output/
 results/
 exports/
+# Allow output package in source
+!src/streamline_vpn/core/output/
+!src/streamline_vpn/core/output/**
+src/streamline_vpn/core/output/__pycache__/
 
 # Cache directories
 cache/

--- a/src/streamline_vpn/core/output/__init__.py
+++ b/src/streamline_vpn/core/output/__init__.py
@@ -1,0 +1,13 @@
+"""Output formatters for StreamlineVPN."""
+
+from .raw_formatter import RawFormatter
+from .json_formatter import JSONFormatter
+from .clash_formatter import ClashFormatter
+from .singbox_formatter import SingBoxFormatter
+
+__all__ = [
+    "RawFormatter",
+    "JSONFormatter",
+    "ClashFormatter",
+    "SingBoxFormatter",
+]

--- a/src/streamline_vpn/core/output/clash_formatter.py
+++ b/src/streamline_vpn/core/output/clash_formatter.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+from ...models.configuration import VPNConfiguration
+
+
+class ClashFormatter:
+    """Formatter that outputs configurations in a simple YAML structure for Clash."""
+
+    def __init__(self, output_dir: Path) -> None:
+        self.output_dir = output_dir
+
+    def get_file_extension(self) -> str:
+        """Return the file extension for Clash YAML output."""
+        return ".yaml"
+
+    def save_configurations(self, configs: List[VPNConfiguration], base_filename: str) -> Path:
+        """Save configurations in a basic YAML-like format.
+
+        This implementation intentionally avoids external YAML dependencies.
+        """
+        file_path = self.output_dir / f"{base_filename}{self.get_file_extension()}"
+        f = open(file_path, "w", encoding="utf-8")
+        try:
+            f.write("proxies:\n")
+            for cfg in configs:
+                f.write(f"  - {cfg.to_dict()}\n")
+        finally:
+            f.close()
+        return file_path

--- a/src/streamline_vpn/core/output/json_formatter.py
+++ b/src/streamline_vpn/core/output/json_formatter.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List
+
+from ...models.configuration import VPNConfiguration
+
+
+class JSONFormatter:
+    """Formatter that outputs configurations in JSON format."""
+
+    def __init__(self, output_dir: Path) -> None:
+        self.output_dir = output_dir
+
+    def get_file_extension(self) -> str:
+        """Return the file extension for JSON output."""
+        return ".json"
+
+    def save_configurations(self, configs: List[VPNConfiguration], base_filename: str) -> Path:
+        """Serialize configurations to a JSON file."""
+        file_path = self.output_dir / f"{base_filename}{self.get_file_extension()}"
+        f = open(file_path, "w", encoding="utf-8")
+        try:
+            json.dump([cfg.to_dict() for cfg in configs], f, indent=2)
+        finally:
+            f.close()
+        return file_path

--- a/src/streamline_vpn/core/output/raw_formatter.py
+++ b/src/streamline_vpn/core/output/raw_formatter.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+from ...models.configuration import VPNConfiguration
+
+
+class RawFormatter:
+    """Formatter that writes configurations as raw strings."""
+
+    def __init__(self, output_dir: Path) -> None:
+        self.output_dir = output_dir
+
+    def get_file_extension(self) -> str:
+        """Return the file extension for raw output."""
+        return ".txt"
+
+    def save_configurations(self, configs: List[VPNConfiguration], base_filename: str) -> Path:
+        """Save configurations as plain text.
+
+        Each configuration is written on a new line using its string representation.
+        """
+        file_path = self.output_dir / f"{base_filename}{self.get_file_extension()}"
+        f = open(file_path, "w", encoding="utf-8")
+        try:
+            for config in configs:
+                f.write(str(config) + "\n")
+        finally:
+            f.close()
+        return file_path

--- a/src/streamline_vpn/core/output/singbox_formatter.py
+++ b/src/streamline_vpn/core/output/singbox_formatter.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List
+
+from ...models.configuration import VPNConfiguration
+
+
+class SingBoxFormatter:
+    """Formatter that outputs configurations in a minimal Sing-box JSON structure."""
+
+    def __init__(self, output_dir: Path) -> None:
+        self.output_dir = output_dir
+
+    def get_file_extension(self) -> str:
+        """Return the file extension for Sing-box output."""
+        return ".json"
+
+    def save_configurations(self, configs: List[VPNConfiguration], base_filename: str) -> Path:
+        """Save configurations in a simple Sing-box format."""
+        file_path = self.output_dir / f"{base_filename}{self.get_file_extension()}"
+        f = open(file_path, "w", encoding="utf-8")
+        try:
+            data = {
+                "outbounds": [cfg.to_dict() for cfg in configs]
+            }
+            json.dump(data, f, indent=2)
+        finally:
+            f.close()
+        return file_path


### PR DESCRIPTION
### **User description**
## Summary
- add `core/output` package with `RawFormatter`, `JSONFormatter`, `ClashFormatter`, and `SingBoxFormatter`
- export new formatters via `streamline_vpn.core.output.__all__`
- allow output package to be tracked in `.gitignore`

## Testing
- `PYTHONPATH=src python -m pytest tests/test_core.py::TestOutputManager::test_save_configurations -q`
- `PYTHONPATH=src python -m pytest -q` *(fails: fixture 'aiohttp_server' not found; VLESS parser assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf0e5de04832e9ee71b7a72dc4438


___

### **PR Type**
Enhancement


___

### **Description**
- Add new output formatters package with four formatter classes

- Implement RawFormatter, JSONFormatter, ClashFormatter, and SingBoxFormatter

- Each formatter supports different output formats for VPN configurations

- All formatters follow consistent interface with `save_configurations` method


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["VPNConfiguration"] --> B["Output Formatters"]
  B --> C["RawFormatter (.txt)"]
  B --> D["JSONFormatter (.json)"]
  B --> E["ClashFormatter (.yaml)"]
  B --> F["SingBoxFormatter (.json)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Package initialization with formatter exports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/streamline_vpn/core/output/__init__.py

<ul><li>Create package initialization file<br> <li> Import all four formatter classes<br> <li> Define <code>__all__</code> exports for public API</ul>


</details>


  </td>
  <td><a href="https://github.com/AmirrezaFarnamTaheri/StreamlineVPN/pull/44/files#diff-cf9dff2d16500814df29659ebc86465838bdbd69a7a1cebdecdc89b5e8ae1cb9">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>raw_formatter.py</strong><dd><code>Raw text formatter implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/streamline_vpn/core/output/raw_formatter.py

<ul><li>Implement <code>RawFormatter</code> class for plain text output<br> <li> Save configurations as raw strings with <code>.txt</code> extension<br> <li> Write each configuration on separate line</ul>


</details>


  </td>
  <td><a href="https://github.com/AmirrezaFarnamTaheri/StreamlineVPN/pull/44/files#diff-33a203b5f48e2a0727f8dacb5fa1f44264d16a058c71cf557b8bac5b5deaed29">+31/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>json_formatter.py</strong><dd><code>JSON formatter implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/streamline_vpn/core/output/json_formatter.py

<ul><li>Implement <code>JSONFormatter</code> class for JSON output<br> <li> Serialize configurations to JSON with indentation<br> <li> Use <code>.json</code> file extension</ul>


</details>


  </td>
  <td><a href="https://github.com/AmirrezaFarnamTaheri/StreamlineVPN/pull/44/files#diff-c0c023f8d45040e9b42b9d0c0d05e0945c537839c9586d4f6b13980b7b63aeec">+28/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>clash_formatter.py</strong><dd><code>Clash YAML formatter implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/streamline_vpn/core/output/clash_formatter.py

<ul><li>Implement <code>ClashFormatter</code> for Clash YAML format<br> <li> Create basic YAML structure without external dependencies<br> <li> Output configurations under <code>proxies</code> key</ul>


</details>


  </td>
  <td><a href="https://github.com/AmirrezaFarnamTaheri/StreamlineVPN/pull/44/files#diff-a039e9fdf2b64deadb2dcee7cc366b8c235f012cc22815df619970ab8e40995f">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>singbox_formatter.py</strong><dd><code>Sing-box JSON formatter implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/streamline_vpn/core/output/singbox_formatter.py

<ul><li>Implement <code>SingBoxFormatter</code> for Sing-box JSON format<br> <li> Wrap configurations in <code>outbounds</code> structure<br> <li> Use JSON format with proper indentation</ul>


</details>


  </td>
  <td><a href="https://github.com/AmirrezaFarnamTaheri/StreamlineVPN/pull/44/files#diff-21bae001e06d1cff84be17070566d9754ac5db36687f219884ec3aab3577cb4e">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

