### PR TITLE
Refactor sync configuration saving and add tests

### DIFF
--- a/src/streamline_vpn/core/output_manager.py
+++ b/src/streamline_vpn/core/output_manager.py
@@ -5,16 +5,18 @@ Output Manager (Refactored)
 Refactored output management system for StreamlineVPN.
 """
 
+# isort:skip_file
+
 from pathlib import Path
-from typing import List, Optional, Dict, Any, Union
+from typing import Dict, List, Optional, Union
 
 from ..models.configuration import VPNConfiguration
 from ..utils.logging import get_logger
 from .output import (
-    JSONFormatter,
     ClashFormatter,
+    JSONFormatter,
+    RawFormatter,  # isort:skip
     SingBoxFormatter,
-    RawFormatter,
 )
 
 logger = get_logger(__name__)
@@ -39,12 +41,12 @@ class OutputManager:
         formats: Optional[Union[List[str], str]] = None,
     ) -> Union[Dict[str, Path], Path, None]:
         """Save configurations in specified formats.
-        
+
         Args:
             configs: List of VPN configurations to save
             output_dir: Output directory path
             formats: List of formats to generate (default: ['json', 'clash'])
-            
+
         Returns:
             Dictionary mapping format names to file paths
         """
@@ -64,7 +66,7 @@ class OutputManager:
         output_path.mkdir(parents=True, exist_ok=True)
 
         saved_files: Dict[str, Path] = {}
-        
+
         for format_name in formats:
             try:
                 if format_name not in self.formatters:
@@ -75,11 +77,15 @@ class OutputManager:
                 formatter = formatter_class(output_path)
 
                 # Determine target path early for fallback on write errors
-                target_path = output_path / f"configurations{formatter.get_file_extension()}"
+                target_path = (
+                    output_path / f"configurations{formatter.get_file_extension()}"
+                )
                 try:
                     file_path = formatter.save_configurations(configs, "configurations")
                     saved_files[format_name] = file_path
-                    logger.info(f"Saved {len(configs)} configurations in {format_name} format")
+                    logger.info(
+                        f"Saved {len(configs)} configurations in {format_name} format"
+                    )
                 except Exception as e:
                     # Gracefully degrade when file IO is mocked or fails
                     logger.error(f"Failed to save {format_name} format: {e}")
@@ -107,15 +113,18 @@ class OutputManager:
 
         try:
             asyncio.get_running_loop()
-            # Running in an event loop; avoid deadlock
-            raise RuntimeError("save_configurations_sync cannot run inside an event loop")
         except RuntimeError:
             # No running loop
             return asyncio.run(self.save_configurations(configs, output_dir, formats))
+        else:
+            # Running in an event loop; avoid deadlock
+            raise RuntimeError(
+                "save_configurations_sync cannot run inside an event loop"
+            )
 
     def get_supported_formats(self) -> List[str]:
         """Get list of supported output formats.
-        
+
         Returns:
             List of supported format names
         """
@@ -123,10 +132,10 @@ class OutputManager:
 
     def validate_format(self, format_name: str) -> bool:
         """Validate if format is supported.
-        
+
         Args:
             format_name: Format name to validate
-            
+
         Returns:
             True if format is supported
         """


### PR DESCRIPTION
## Summary
- guard `save_configurations_sync` against running inside an event loop
- add unit tests covering synchronous wrapper in and out of event loop

## Testing
- `pre-commit run --files src/streamline_vpn/core/output_manager.py tests/test_core.py`
- `PYTHONPATH=src pytest tests/test_core.py::TestOutputManager::test_save_configurations_sync_raises_in_event_loop tests/test_core.py::TestOutputManager::test_save_configurations_sync_runs_outside_event_loop -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbf0f08d28832ea4d8a8fc9a3e6d38