### PR TITLE
fix: remove whitespace and unused imports

### DIFF
--- a/src/streamline_vpn/web/static_server.py
+++ b/src/streamline_vpn/web/static_server.py
@@ -39,7 +39,11 @@ class StaticFileServer:
         app = FastAPI(title="StreamlineVPN Static Server")
 
         # Create static directory if it doesn't exist
-        self.static_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            self.static_dir.mkdir(parents=True, exist_ok=True)
+        except Exception as e:
+            logger.error(f"Failed to create static directory '{self.static_dir}': {e}")
+            raise
 
         # Mount static files
         app.mount("/static", StaticFiles(directory=str(self.static_dir)), name="static")

--- a/src/streamline_vpn/web/static_server.py
+++ b/src/streamline_vpn/web/static_server.py
@@ -62,7 +62,7 @@ class StaticFileServer:
             if full_path.exists() and full_path.is_file():
                 return FileResponse(str(full_path))
             else:
-                return {"error": "File not found"}
+                return {"error": "File not found"}, 404
 
         return app
 

--- a/src/streamline_vpn/web/static_server.py
+++ b/src/streamline_vpn/web/static_server.py
@@ -39,7 +39,7 @@ class StaticFileServer:
         app = FastAPI(title="StreamlineVPN Static Server")
 
         # Create static directory if it doesn't exist
-        self.static_dir.mkdir(exist_ok=True)
+        self.static_dir.mkdir(parents=True, exist_ok=True)
 
         # Mount static files
         app.mount("/static", StaticFiles(directory=str(self.static_dir)), name="static")

--- a/src/streamline_vpn/web/static_server.py
+++ b/src/streamline_vpn/web/static_server.py
@@ -5,23 +5,25 @@ Static File Server
 Static file server for StreamlineVPN web interface.
 """
 
-import os
 from pathlib import Path
-from typing import Optional
+
 from fastapi import FastAPI
-from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
 
 from ..utils.logging import get_logger
 
 logger = get_logger(__name__)
 
+
 class StaticFileServer:
     """Static file server for StreamlineVPN."""
-    
-    def __init__(self, host: str = "127.0.0.1", port: int = 9000, static_dir: str = "static"):
+
+    def __init__(
+        self, host: str = "127.0.0.1", port: int = 9000, static_dir: str = "static"
+    ):
         """Initialize static file server.
-        
+
         Args:
             host: Host to bind to
             port: Port to bind to
@@ -31,17 +33,17 @@ class StaticFileServer:
         self.port = port
         self.static_dir = Path(static_dir)
         self.app = self._create_static_app()
-    
+
     def _create_static_app(self) -> FastAPI:
         """Create static file FastAPI application."""
         app = FastAPI(title="StreamlineVPN Static Server")
-        
+
         # Create static directory if it doesn't exist
         self.static_dir.mkdir(exist_ok=True)
-        
+
         # Mount static files
         app.mount("/static", StaticFiles(directory=str(self.static_dir)), name="static")
-        
+
         # Serve index.html at root
         @app.get("/")
         async def serve_index():
@@ -50,26 +52,26 @@ class StaticFileServer:
                 return FileResponse(str(index_file))
             else:
                 return {"message": "StreamlineVPN Static Server", "files": "/static"}
-        
+
         # Serve any file from static directory
         @app.get("/{file_path:path}")
         async def serve_file(file_path: str):
             file_path = Path(file_path)
             full_path = self.static_dir / file_path
-            
+
             if full_path.exists() and full_path.is_file():
                 return FileResponse(str(full_path))
             else:
                 return {"error": "File not found"}
-        
+
         return app
-    
+
     async def start(self):
         """Start the static file server."""
         logger.info(f"Starting Static File Server on {self.host}:{self.port}")
         # Note: In a real implementation, you would use uvicorn to run the app
         # uvicorn.run(self.app, host=self.host, port=self.port)
-    
+
     async def stop(self):
         """Stop the static file server."""
         logger.info("Stopping Static File Server")


### PR DESCRIPTION
### **User description**
## Summary
- remove trailing whitespace in static file server
- drop unused imports flagged by linter

## Testing
- `pre-commit run --files src/streamline_vpn/web/static_server.py`

------
https://chatgpt.com/codex/tasks/task_e_68bc06522910832ea0f846cc3b93874f


___

### **PR Type**
Other


___

### **Description**
- Remove unused imports (`os` and `typing.Optional`)

- Fix trailing whitespace throughout the file

- Reorder imports for better organization

- Improve code formatting consistency


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>static_server.py</strong><dd><code>Code cleanup and import optimization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/streamline_vpn/web/static_server.py

<ul><li>Removed unused <code>os</code> and <code>typing.Optional</code> imports<br> <li> Fixed trailing whitespace on multiple lines<br> <li> Reordered imports with proper spacing<br> <li> Improved method parameter formatting consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/AmirrezaFarnamTaheri/StreamlineVPN/pull/52/files#diff-6f9b6a0a5fe1374c91ebcabad97a34c20775066349f2bd394f78a9c1996e450d">+17/-15</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

