### PR TITLE
Fix lint issues and refine documentation UI

### DIFF
--- a/docs/assets/site.css
+++ b/docs/assets/site.css
@@ -265,6 +265,37 @@ pre {
   text-align: center;
 }
 
+/* Output preview */
+details {
+  margin-bottom: 1rem;
+  border: 1px solid var(--light-border);
+  border-radius: var(--border-radius);
+  padding: 0.5rem 1rem;
+}
+details[open] {
+  background-color: var(--light-code-bg);
+}
+details summary {
+  cursor: pointer;
+  font-weight: 600;
+  outline: none;
+  word-break: break-all;
+}
+details pre {
+  margin-top: 0.5rem;
+  overflow-x: auto;
+  white-space: pre;
+}
+.output-actions {
+  margin: 0.5rem 0;
+}
+[data-theme="dark"] details {
+  border-color: var(--dark-border);
+}
+[data-theme="dark"] details[open] {
+  background-color: var(--dark-code-bg);
+}
+
 [data-theme="dark"] .site-footer {
   border-top-color: var(--dark-border);
   color: #8b949e;

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,6 +12,7 @@ title: StreamlineVPN • Project Home
   <div class="cta">
     <a class="btn" href="quick-start.html">Get Started</a>
     <a class="btn secondary" href="api/openapi.yaml">View API Specs</a>
+    <a class="btn secondary" href="interactive.html">Run in Browser</a>
   </div>
 </section>
 

--- a/docs/interactive.html
+++ b/docs/interactive.html
@@ -38,6 +38,7 @@ title: Interactive Pipeline Runner • StreamlineVPN
 
   <div class="card" style="margin-top: 2rem;">
     <h2>Output Files</h2>
+    <p class="muted">Preview, copy, or download the generated files.</p>
     <div id="output-files">
       <p>Pipeline has not been run yet.</p>
     </div>

--- a/src/streamline_vpn/web/graphql/resolvers.py
+++ b/src/streamline_vpn/web/graphql/resolvers.py
@@ -1,15 +1,9 @@
+"""GraphQL resolvers placeholder.
+
+Resolvers are currently defined directly in :mod:`schema`.
+This module remains for future expansion.
 """
-GraphQL Resolvers
-=================
 
-GraphQL resolvers for StreamlineVPN.
-"""
+from .schema import Mutation, Query  # noqa: F401
 
-import asyncio
-from typing import List, Optional
-from datetime import datetime
-
-from .schema import Query, Mutation
-
-# Resolvers are defined in the schema file
-# This file is kept for future expansion
+# Resolvers are defined in schema; these imports re-export Query/Mutation

--- a/src/streamline_vpn/web/graphql/schema.py
+++ b/src/streamline_vpn/web/graphql/schema.py
@@ -5,9 +5,10 @@ GraphQL Schema
 GraphQL schema definitions for StreamlineVPN.
 """
 
-import strawberry
-from typing import List, Optional
 from datetime import datetime
+from typing import List, Optional
+
+import strawberry
 
 
 @strawberry.type
@@ -116,14 +117,14 @@ class Mutation:
         """Blacklist a source."""
         # Return placeholder to avoid circular imports
         # In a real implementation, this would be injected
-        return f"Blacklist not available in GraphQL mode"
+        return "Blacklist not available in GraphQL mode"
 
     @strawberry.field
     def whitelist_source(self, source_url: str) -> str:
         """Whitelist a source."""
         # Return placeholder to avoid circular imports
         # In a real implementation, this would be injected
-        return f"Whitelist not available in GraphQL mode"
+        return "Whitelist not available in GraphQL mode"
 
 
 # Create schema

--- a/src/streamline_vpn/web/integrated_server.py
+++ b/src/streamline_vpn/web/integrated_server.py
@@ -5,14 +5,12 @@ Integrated Web Server
 Integrated web server combining all StreamlineVPN web services.
 """
 
-import asyncio
-from typing import Optional
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from ..utils.logging import get_logger
 from .api import create_app as create_api_app
 from .graphql import create_graphql_app
-from ..utils.logging import get_logger
 
 logger = get_logger(__name__)
 


### PR DESCRIPTION
## Summary
- fix lint errors in GraphQL schema and integrated server
- add interactive output previews with copy/download buttons
- expose interactive runner from docs homepage
- sanitize interactive preview filenames and revoke object URLs
- clean up GraphQL resolvers imports

## Testing
- `pre-commit run --files docs/assets/site.css docs/assets/site.js src/streamline_vpn/web/graphql/resolvers.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc753d8670832e9abdc528f5b002da