### PR TITLE
chore: fix linter issues

### DIFF
--- a/src/streamline_vpn/core/source_manager.py
+++ b/src/streamline_vpn/core/source_manager.py
@@ -89,8 +89,10 @@ class SourceManager:
                                 f"Invalid or unsafe source URL: {url}"
                             )
                     elif isinstance(source_config, str):
-                        validation_result = self.security_manager.validate_source(
-                            source_config
+                        validation_result = (
+                            self.security_manager.validate_source(
+                                source_config
+                            )
                         )
                         if validation_result["is_safe"]:
                             metadata = SourceMetadata(
@@ -103,7 +105,8 @@ class SourceManager:
                             self.sources[source_config] = metadata
                         else:
                             logger.warning(
-                                f"Invalid or unsafe source URL: {source_config}"
+                                "Invalid or unsafe source URL: %s",
+                                source_config,
                             )
 
             logger.info(

--- a/src/streamline_vpn/discovery/manager.py
+++ b/src/streamline_vpn/discovery/manager.py
@@ -365,9 +365,18 @@ class DiscoveryManager:
         public_lists = [
             "https://raw.githubusercontent.com/freefq/free/master/v2",
             "https://raw.githubusercontent.com/Pawdroid/Free-servers/main/sub",
-            "https://raw.githubusercontent.com/ermaozi/get_subscribe/main/subscribe/v2ray.txt",
-            "https://raw.githubusercontent.com/vveg26/get_proxy/main/dist/v2ray.config.txt",
-            "https://raw.githubusercontent.com/mianfeifq/share/main/data2023087.txt",
+            (
+                "https://raw.githubusercontent.com/ermaozi/"
+                "get_subscribe/main/subscribe/v2ray.txt"
+            ),
+            (
+                "https://raw.githubusercontent.com/vveg26/"
+                "get_proxy/main/dist/v2ray.config.txt"
+            ),
+            (
+                "https://raw.githubusercontent.com/mianfeifq/"
+                "share/main/data2023087.txt"
+            ),
         ]
 
         async with aiohttp.ClientSession() as session:

--- a/src/streamline_vpn/jobs/job_executor.py
+++ b/src/streamline_vpn/jobs/job_executor.py
@@ -30,7 +30,9 @@ class JobExecutor:
     def _register_default_handlers(self) -> None:
         """Register default job handlers."""
         self.job_handlers = {
-            JobType.PROCESS_CONFIGURATIONS: self._handle_process_configurations,
+            JobType.PROCESS_CONFIGURATIONS: (
+                self._handle_process_configurations
+            ),
             JobType.DISCOVER_SOURCES: self._handle_discover_sources,
             JobType.UPDATE_SOURCES: self._handle_update_sources,
             JobType.CLEAR_CACHE: self._handle_clear_cache,

--- a/src/streamline_vpn/web/api/routes.py
+++ b/src/streamline_vpn/web/api/routes.py
@@ -348,7 +348,8 @@ def setup_routes(
                 if formats:
                     for format_name in formats:
                         # Construct file path based on format
-                        # This logic needs to be robust and match the output of the merger
+                        # This logic needs to be robust
+                        # and match the output of the merger
                         if format_name == "json":
                             file_name = "vpn_data.json"
                         elif format_name == "clash":

--- a/src/streamline_vpn/web/graphql/schema.py
+++ b/src/streamline_vpn/web/graphql/schema.py
@@ -200,7 +200,7 @@ class Query:
                 continue
             filtered_configs.append(cfg)
 
-        paginated = filtered_configs[offset : offset + limit]
+        paginated = filtered_configs[offset:offset + limit]
 
         return [
             VPNConfiguration(

--- a/src/streamline_vpn/web/static_server.py
+++ b/src/streamline_vpn/web/static_server.py
@@ -144,7 +144,11 @@ class EnhancedStaticServer:
             if format == "text":
                 text_output = "\n".join(
                     [
-                        f"{c.get('protocol', 'unknown')}://{c.get('server', 'unknown')}:{c.get('port', 0)}"
+                        (
+                            f"{c.get('protocol', 'unknown')}://"
+                            f"{c.get('server', 'unknown')}:"
+                            f"{c.get('port', 0)}"
+                        )
                         for c in configs
                     ]
                 )
@@ -154,12 +158,15 @@ class EnhancedStaticServer:
                 )
             if format == "download":
                 file_content = json.dumps(configs, indent=2)
+                timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
                 return HTMLResponse(
                     content=file_content,
                     media_type="application/json",
                     headers={
-                        "Content-Disposition": "attachment; filename="
-                        f"vpn_configs_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json",
+                        "Content-Disposition": (
+                            "attachment; filename="
+                            f"vpn_configs_{timestamp}.json"
+                        ),
                     },
                 )
             raise HTTPException(status_code=400, detail="Invalid format")


### PR DESCRIPTION
## Summary
- wrap long lines and clean up logging
- split long URLs and update slice formatting
- break up long strings in static server responses

## Testing
- `flake8 src/streamline_vpn/core/source_manager.py src/streamline_vpn/discovery/manager.py src/streamline_vpn/jobs/job_executor.py src/streamline_vpn/web/api/routes.py src/streamline_vpn/web/graphql/schema.py src/streamline_vpn/web/static_server.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be11439a14832eb93cefc39f482ca4