### PR TITLE
Update interactive health and pipeline endpoints; relax status auth

### DIFF
--- a/docs/interactive.html
+++ b/docs/interactive.html
@@ -538,7 +538,7 @@
             document.getElementById('processingResults').classList.add('hidden');
             
             try {
-                const response = await fetch(`${API_BASE}/api/v1/process`, {
+                const response = await fetch(`${API_BASE}/api/v1/pipeline/run`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
@@ -743,7 +743,7 @@
         async function testConnection() {
             addTerminalLine('Testing API connection...', 'info');
             try {
-                const response = await fetch(`${API_BASE}/api/v1/health`);
+                const response = await fetch(`${API_BASE}/health`);
                 if (response.ok) {
                     const data = await response.json();
                     addTerminalLine(`Connection successful! API Version: ${data.version || '2.0.0'}`, 'success');

--- a/src/streamline_vpn/web/api/routes.py
+++ b/src/streamline_vpn/web/api/routes.py
@@ -259,8 +259,8 @@ def setup_routes(
 
     # Status routes
     @app.get("/api/v1/status", response_model=VPNStatusResponse)
-    async def get_vpn_status(current_user: User = Depends(get_current_user)):
-        """Get VPN status."""
+    async def get_vpn_status():
+        """Get VPN status without authentication."""
         return VPNStatusResponse(
             connected=True,
             server={


### PR DESCRIPTION
## Summary
- point docs interactive tool to `/api/v1/pipeline/run`
- use `/health` endpoint for connection test
- allow `/api/v1/status` without authentication

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68beb047de1c832eaee5b264277d99a5