### PR TITLE
Use `successful_sources` statistic in API responses

### DIFF
--- a/docs/interactive.html
+++ b/docs/interactive.html
@@ -208,8 +208,8 @@
                 <div id="totalConfigs" class="text-3xl font-bold text-white">0</div>
             </div>
             <div class="glass-morphism rounded-xl p-6 hover-lift">
-                <div class="text-white opacity-75 text-sm mb-2">Active Sources</div>
-                <div id="activeSources" class="text-3xl font-bold text-white">0</div>
+                <div class="text-white opacity-75 text-sm mb-2">Successful Sources</div>
+                <div id="successfulSources" class="text-3xl font-bold text-white">0</div>
             </div>
             <div class="glass-morphism rounded-xl p-6 hover-lift">
                 <div class="text-white opacity-75 text-sm mb-2">Success Rate</div>
@@ -510,7 +510,7 @@
         
         function updateStatistics(stats) {
             document.getElementById('totalConfigs').textContent = stats.total_configs || 0;
-            document.getElementById('activeSources').textContent = stats.active_sources || 0;
+            document.getElementById('successfulSources').textContent = stats.successful_sources || 0;
             document.getElementById('successRate').textContent = `${Math.round((stats.success_rate || 0) * 100)}%`;
             document.getElementById('avgQuality').textContent = (stats.avg_quality || 0).toFixed(2);
 
@@ -523,7 +523,7 @@
         function updateWithMockData() {
             const mockStats = {
                 total_configs: 1250,
-                active_sources: 15,
+                successful_sources: 15,
                 success_rate: 0.92,
                 avg_quality: 0.78
             };

--- a/src/streamline_vpn/web/api.py
+++ b/src/streamline_vpn/web/api.py
@@ -408,7 +408,7 @@ def create_app() -> FastAPI:
         )
         return {
             "total_configs": stats.get("total_configs", 0),
-            "active_sources": stats.get("successful_sources", 0),
+            "successful_sources": stats.get("successful_sources", 0),
             "success_rate": stats.get("success_rate", 0.0),
             "avg_quality": avg_quality,
             "last_update": stats.get("end_time"),

--- a/tests/test_statistics_endpoint.py
+++ b/tests/test_statistics_endpoint.py
@@ -1,0 +1,49 @@
+"""Tests for the `/api/v1/statistics` endpoint in `web/api.py`."""
+
+from importlib import import_module, util
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock, patch
+
+from fastapi.testclient import TestClient
+
+
+def load_web_api_module():
+    """Dynamically load the `web/api.py` module as a submodule."""
+    # Ensure parent package is loaded so relative imports work
+    import_module("streamline_vpn.web")
+    module_path = Path(__file__).resolve().parents[1] / "src" / "streamline_vpn" / "web" / "api.py"
+    spec = util.spec_from_file_location("streamline_vpn.web.api_v1", module_path)
+    module = util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_statistics_returns_successful_sources():
+    """The statistics endpoint should expose `successful_sources`."""
+
+    web_api = load_web_api_module()
+    app = web_api.create_app()
+    client = TestClient(app)
+
+    mock_merger = Mock()
+    mock_merger.get_statistics = AsyncMock(
+        return_value={
+            "total_configs": 10,
+            "successful_sources": 5,
+            "success_rate": 0.5,
+            "end_time": "now",
+        }
+    )
+    mock_merger.get_configurations = AsyncMock(return_value=[])
+
+    with patch.object(web_api, "get_merger", return_value=mock_merger):
+        response = client.get("/api/v1/statistics")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["successful_sources"] == 5
+    assert "active_sources" not in data
+


### PR DESCRIPTION
## Summary
- Ensure `/api/v1/statistics` returns `successful_sources` instead of `active_sources`
- Sync interactive dashboard with `successful_sources` metric
- Add regression test for statistics endpoint

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf0c5517cc832ea1e5753ae662bd51