### PR TITLE
Add output format enum and validation

### DIFF
--- a/docs/interactive.html
+++ b/docs/interactive.html
@@ -304,7 +304,7 @@
                                 Clash
                             </label>
                             <label class="flex items-center text-white">
-                                <input type="checkbox" value="singbox" checked class="mr-2 output-format">
+                                <input type="checkbox" value="singbox" class="mr-2 output-format">
                                 Singbox
                             </label>
                             <label class="flex items-center text-white">

--- a/src/streamline_vpn/models/__init__.py
+++ b/src/streamline_vpn/models/__init__.py
@@ -6,12 +6,14 @@ Data models and schemas for StreamlineVPN.
 """
 
 from .configuration import VPNConfiguration
-from .source import SourceMetadata, SourceTier
+from .output_format import OutputFormat
 from .processing_result import ProcessingResult
+from .source import SourceMetadata, SourceTier
 
 __all__ = [
     "VPNConfiguration",
     "SourceMetadata",
     "SourceTier",
     "ProcessingResult",
+    "OutputFormat",
 ]

--- a/src/streamline_vpn/models/output_format.py
+++ b/src/streamline_vpn/models/output_format.py
@@ -1,0 +1,18 @@
+from enum import Enum
+from typing import List
+
+
+class OutputFormat(str, Enum):
+    """Supported output formats."""
+
+    JSON = "json"
+    CLASH = "clash"
+    SINGBOX = "singbox"
+    BASE64 = "base64"
+    CSV = "csv"
+    RAW = "raw"
+
+    @classmethod
+    def list(cls) -> List[str]:
+        """Return all supported format values."""
+        return [fmt.value for fmt in cls]

--- a/tests/test_pipeline_formats.py
+++ b/tests/test_pipeline_formats.py
@@ -1,0 +1,55 @@
+import importlib.util
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def pipeline_client():
+    spec = importlib.util.spec_from_file_location(
+        "streamline_vpn.web.pipeline_api",
+        Path("src/streamline_vpn/web/api.py"),
+    )
+    api_module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(api_module)
+    app = api_module.create_app()
+    with TestClient(app) as client:
+        yield client
+
+
+def test_run_pipeline_valid_formats(pipeline_client):
+    """Pipeline accepts valid format combinations."""
+    with patch(
+        "streamline_vpn.core.merger.StreamlineVPNMerger.initialize",
+        new=AsyncMock(return_value=None),
+    ), patch(
+        "streamline_vpn.core.merger.StreamlineVPNMerger.process_all",
+        new=AsyncMock(return_value={"status": "success"}),
+    ):
+        response = pipeline_client.post(
+            "/api/v1/pipeline/run",
+            json={
+                "config_path": "tests/fixtures/test_sources.yaml",
+                "output_dir": "output",
+                "formats": ["json", "clash"],
+            },
+        )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "success"
+
+
+def test_run_pipeline_invalid_format(pipeline_client):
+    """Pipeline rejects unsupported formats."""
+    response = pipeline_client.post(
+        "/api/v1/pipeline/run",
+        json={
+            "config_path": "tests/fixtures/test_sources.yaml",
+            "output_dir": "output",
+            "formats": ["json", "invalid"],
+        },
+    )
+    assert response.status_code == 400
+    assert "Unsupported formats" in response.json()["detail"]


### PR DESCRIPTION
### **User description**
## Summary
- define `OutputFormat` enum for supported output formats
- validate pipeline request formats against enum and reject unknown values
- align interactive docs defaults with enum
- test pipeline format validation for valid and invalid cases

## Testing
- `pre-commit run --files src/streamline_vpn/models/output_format.py src/streamline_vpn/models/__init__.py src/streamline_vpn/web/api.py docs/interactive.html tests/test_pipeline_formats.py`
- `pytest tests/test_pipeline_formats.py tests/test_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf0c576f68832e8c9f0e58fd887c2f


___

### **PR Type**
Enhancement


___

### **Description**
- Add `OutputFormat` enum with supported formats (json, clash, singbox, base64, csv, raw)

- Implement format validation in pipeline API endpoint

- Update interactive docs to align with enum defaults

- Add comprehensive tests for format validation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["OutputFormat Enum"] --> B["API Validation"]
  B --> C["Pipeline Request"]
  C --> D["Format Processing"]
  A --> E["Interactive Docs"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>output_format.py</strong><dd><code>Define output format enum</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/streamline_vpn/models/output_format.py

<ul><li>Create <code>OutputFormat</code> enum with six supported formats<br> <li> Add <code>list()</code> class method to return all format values</ul>


</details>


  </td>
  <td><a href="https://github.com/AmirrezaFarnamTaheri/StreamlineVPN/pull/105/files#diff-b0fdb73db1e52ca473c6fc27ccb5ccef39f40cc3d792ad164a6b51194af102f4">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Export OutputFormat enum</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/streamline_vpn/models/__init__.py

<ul><li>Import and export <code>OutputFormat</code> enum<br> <li> Reorder imports alphabetically</ul>


</details>


  </td>
  <td><a href="https://github.com/AmirrezaFarnamTaheri/StreamlineVPN/pull/105/files#diff-ec2d2db6405d95a7f07f90b87ab3a0f07f493f860909eaba61a5c22279818420">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>api.py</strong><dd><code>Implement pipeline format validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/streamline_vpn/web/api.py

<ul><li>Add format validation against <code>OutputFormat</code> enum<br> <li> Update default formats to use enum values<br> <li> Add error handling for invalid and empty formats<br> <li> Reorganize imports with isort</ul>


</details>


  </td>
  <td><a href="https://github.com/AmirrezaFarnamTaheri/StreamlineVPN/pull/105/files#diff-cff9e13a87db6d9c47ead6b17a5cbb5c0c83f4c1aa1d05b2c7242c7f4aac5146">+60/-12</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_pipeline_formats.py</strong><dd><code>Add format validation tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_pipeline_formats.py

<ul><li>Add test for valid format combinations<br> <li> Add test for invalid format rejection<br> <li> Mock pipeline dependencies for testing</ul>


</details>


  </td>
  <td><a href="https://github.com/AmirrezaFarnamTaheri/StreamlineVPN/pull/105/files#diff-2c01bbcb57fc15a37e9a89c511934c24e043346fea77846d225818451fe082cb">+55/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>interactive.html</strong><dd><code>Update interactive docs defaults</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/interactive.html

- Uncheck singbox format by default
- Align with enum default values


</details>


  </td>
  <td><a href="https://github.com/AmirrezaFarnamTaheri/StreamlineVPN/pull/105/files#diff-3001833fecfc5e8121a49859e02b9692a2cd4c06bbaa61f6c51d1944520e0628">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

