### PR TITLE
Fix API base host for web interface

### DIFF
--- a/run_web.py
+++ b/run_web.py
@@ -1,16 +1,17 @@
 """Main entry point for StreamlineVPN with web interface."""
 
-import sys
 import os
+import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent / "src"))
 
 from streamline_vpn.utils.logging import get_logger
-from streamline_vpn.web.static_server import EnhancedStaticServer
 from streamline_vpn.web.settings import Settings
+from streamline_vpn.web.static_server import EnhancedStaticServer
 
 logger = get_logger(__name__)
+
 
 def main() -> None:
     """Run the enhanced StreamlineVPN web interface."""
@@ -25,7 +26,7 @@ def main() -> None:
     server = EnhancedStaticServer(settings=settings)
 
     # Add API base configuration
-    server.app.state.api_base = f"http://{host}:{api_port}"
+    server.app.state.api_base = f"http://localhost:{api_port}"
 
     @server.app.middleware("http")
     async def add_security_headers(request, call_next):  # noqa: ANN001
@@ -76,6 +77,7 @@ def main() -> None:
         ssl_keyfile=ssl_keyfile,
         ssl_certfile=ssl_certfile,
     )
+
 
 if __name__ == "__main__":
     try:

--- a/src/streamline_vpn/web/settings.py
+++ b/src/streamline_vpn/web/settings.py
@@ -11,13 +11,21 @@ class Settings(BaseSettings):
     HOST: str = "0.0.0.0"
     PORT: int = 8000
     STATIC_DIR: str = "docs"
-    API_BASE: str = "http://0.0.0.0:8080"
+    API_BASE: str = "http://localhost:8080"
     UPDATE_INTERVAL: int = 28800  # 8 hours in seconds
 
     # CORS settings for static server
-    ALLOWED_ORIGINS: list[str] = ["http://localhost:3000", "http://localhost:8000", "http://localhost:8080"]
+    ALLOWED_ORIGINS: list[str] = [
+        "http://localhost:3000",
+        "http://localhost:8000",
+        "http://localhost:8080",
+    ]
     ALLOWED_METHODS: list[str] = ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
-    ALLOWED_HEADERS: list[str] = ["Content-Type", "Authorization", "X-Requested-With"]
+    ALLOWED_HEADERS: list[str] = [
+        "Content-Type",
+        "Authorization",
+        "X-Requested-With",
+    ]
     ALLOW_CREDENTIALS: bool = True
 
 


### PR DESCRIPTION
## Summary
- ensure web app exposes a reachable API host using localhost
- default API_BASE to `http://localhost:8080`

## Testing
- `pre-commit run --files run_web.py src/streamline_vpn/web/settings.py`
- `PYTHONPATH=src pytest tests/test_web_api_sources.py -q`
- `python scripts/smoke_test.py`

------
https://chatgpt.com/codex/tasks/task_e_68c04db8ee20832ea2dbbea3ac709373